### PR TITLE
TUVA version and Eligibility schema upgrade

### DIFF
--- a/models/final/eligibility.sql
+++ b/models/final/eligibility.sql
@@ -80,7 +80,9 @@ select distinct
     , cast(null as {{ dbt.type_string() }} ) as original_reason_entitlement_code
     , cast(null as {{ dbt.type_string() }} ) as dual_status_code
     , cast(m.medicare_status_code as {{ dbt.type_string() }} ) as medicare_status_code
+    , cast(null as {{ dbt.type_string() }} ) as name_suffix
     , cast(name_0_family as {{ dbt.type_string() }} ) as first_name
+    , cast(name_0_given_1 as {{ dbt.type_string() }} ) as middle_name
     , cast(name_0_given_0 as {{ dbt.type_string() }} ) as last_name
     , cast(null as {{ dbt.type_string() }} ) as social_security_number
     , cast(null as {{ dbt.type_string() }} ) as subscriber_relation
@@ -89,6 +91,8 @@ select distinct
     , cast(address_0_state as {{ dbt.type_string() }} ) as state
     , cast(address_0_postalcode as {{ dbt.type_string() }} ) as zip_code
     , cast(null as {{ dbt.type_string() }} ) as phone
+    , cast(null as {{ dbt.type_string() }} ) as email
+    , cast(null as {{ dbt.type_string() }} ) as ethnicity
     , cast('bcda' as {{ dbt.type_string() }} ) as data_source
     , cast(pat.filename as {{ dbt.type_string() }} ) as file_name
     , cast(pat.processed_datetime as timestamp) as ingest_datetime

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -2,5 +2,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.2.0
   - package: tuva-health/the_tuva_project
-    version: 0.10.2
+    version: 0.15.0
 sha1_hash: 10a9f86d4b8e23a96e86a72590c822c2f14b2cc7

--- a/packages.yml
+++ b/packages.yml
@@ -2,4 +2,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.9.2"]
   - package: tuva-health/the_tuva_project
-    version: [">=0.10.0","<0.11.0"]
+    version: [">=0.15.0","<0.16.0"]


### PR DESCRIPTION
## Describe your changes
- The TUVA version has been upgraded to `v0.15`
- The additional fields: `name_suffix`, `middle_name`, `email`, and `ethnicity` has been added to eligibility model.
  - `name_suffix` has been set to `NULL`
  - `middle_name` has been pointed to `name_0_given_1`
  -  `email` has been set to `NULL`
  -  `ethnicity` has been set to `NULL`


## How has this been tested?
It has been tested using:
- dbt clean
- dbt deps


## Reviewer focus
- Please focus on `packages.yml` file for version upgrade
- Please focus towards additional fields on `models.final.eligibility.sql`


## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [ ]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
