### PR TITLE
Fix claims data model link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check out our [docs](https://thetuvaproject.com/) to learn about the project and
 <br/><br/>
 
 ## 🧰  What does this repo do?
-The Medicare BCDA Connector is a dbt package that maps Medicare BCDA claims data to the Tuva [claims data model](https://thetuvaproject.com/claims-data/data-model/about) which then makes it simple to run the entire [Tuva Project](https://github.com/tuva-health/the_tuva_project).
+The Medicare BCDA Connector is a dbt package that maps Medicare BCDA claims data to the Tuva [claims data model](https://thetuvaproject.com/input-layer) which then makes it simple to run the entire [Tuva Project](https://github.com/tuva-health/the_tuva_project).
 <br/><br/>  
 
 ## 🔌 Database Support


### PR DESCRIPTION
## Describe your changes
Updated the "claims data model" link in the README from `https://thetuvaproject.com/claims-data/data-model/about` to `https://thetuvaproject.com/input-layer` (correct docs URL).

## How has this been tested?
Verified the new URL loads; the previous path appears broken/redirected.

## Reviewer focus
Confirm the input-layer URL is the intended docs target for "claims data model."

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [ ] (New models) N/A — README only
- [ ] (Optional) I have recorded a Loom to explain this PR

Made with [Cursor](https://cursor.com)